### PR TITLE
fix s18 -> s19; correct links now in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,25 +1,10 @@
 
 <html>
 <body>
-<h2>https://amueller.github.io/COMS4995-s18/slides/</h2>
+<h2>https://amueller.github.io/COMS4995-s19/slides/</h2>
 <p>
-    <li><a href=".ipynb_checkpoints">.ipynb_checkpoints</a></li>
-    <li><a href="aml-01-011718-introduction">aml-01-011718-introduction</a></li>
-    <li><a href="aml-02-012218-python-git-testing">aml-02-012218-python-git-testing</a></li>
-    <li><a href="aml-03-012418-matplotlib">aml-03-012418-matplotlib</a></li>
-    <li><a href="aml-04-012918-supervised-learning">aml-04-012918-supervised-learning</a></li>
-    <li><a href="aml-05-013118-linear-models-regression">aml-05-013118-linear-models-regression</a></li>
-    <li><a href="aml-06-020518-linear-models-classification">aml-06-020518-linear-models-classification</a></li>
-    <li><a href="aml-07-020718-preprocessing">aml-07-020718-preprocessing</a></li>
-    <li><a href="aml-08-021218-imputation-feature-selection">aml-08-021218-imputation-feature-selection</a></li>
-    <li><a href="aml-09-021418-support-vector-machines">aml-09-021418-support-vector-machines</a></li>
-    <li><a href="aml-10-021918-trees-forests">aml-10-021918-trees-forests</a></li>
-    <li><a href="aml-11-022118-gradient-boosting-calibration">aml-11-022118-gradient-boosting-calibration</a></li>
-    <li><a href="aml-12-022618-model-evaluation">aml-12-022618-model-evaluation</a></li>
-    <li><a href="aml-13-022818-resampling-imbalanced-data">aml-13-022818-resampling-imbalanced-data</a></li>
-    <li><a href="aml-15-031918-pca-discriminants-manifold-learning">aml-15-031918-pca-discriminants-manifold-learning</a></li>
-    <li><a href="aml-16-032118-clustering-and-mixture-models">aml-16-032118-clustering-and-mixture-models</a></li>
-    <li><a href="aml-17-032818-clustering-evaluation">aml-17-032818-clustering-evaluation</a></li>
+    <li><a href="homeworks">homeworks</a></li>
+    <li><a href="slides">slides</a></li>
 </p>
 </body>
 </html>

--- a/make_index.py
+++ b/make_index.py
@@ -16,7 +16,7 @@ INDEX_TEMPLATE = r"""
 </html>
 """
 
-EXCLUDED = ['index.html']
+EXCLUDED = ['index.html', '.git']
 
 import os
 
@@ -28,7 +28,7 @@ def main():
     directory = os.getcwd()
     fnames = [fname for fname in sorted(os.listdir(directory))
               if fname not in EXCLUDED and os.path.isdir(fname)]
-    header = "https://amueller.github.io/COMS4995-s18/slides/"
+    header = "https://amueller.github.io/COMS4995-s19/slides/"
     with open("index.html", "w") as f:
         f.write(Template(INDEX_TEMPLATE).render(names=fnames, header=header))
 


### PR DESCRIPTION
Current version of the base make_index.py and index.html point to the S18 repo and breaks the links in index.html